### PR TITLE
feat: allow route exclusions

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,17 +47,22 @@ class RouteManifest {
 			chunks.forEach(chunk => {
 				const { id, files, origins } = chunk;
 				const origin = origins[0].request;
-				Pages[id] = {
-					assets: new Set(files),
-					pattern: origin ? toRoute(origin) : '*'
-				};
+				const route = origin ? toRoute(origin) : '*';
+				if (route) {
+					Pages[id] = {
+						assets: new Set(files),
+						pattern: route
+					};
+				}
 			});
 
 			// Grab extra files per route
 			modules.forEach(mod => {
 				mod.assets.forEach(asset => {
 					mod.chunks.forEach(id => {
-						Pages[id].assets.add(asset);
+						if (Pages[id]) {
+							Pages[id].assets.add(asset);
+						}
 					});
 				});
 			});

--- a/readme.md
+++ b/readme.md
@@ -79,6 +79,8 @@ When `routes` is a function, it receives the strings and expects a pattern (stri
 
 When `routes` is an object, its keys must be the expected import paths and its values must be the pattern strings.
 
+> **Important:** You may also return a falsey value to exclude the route from the manifest.
+
 ***Example***
 
 Let's assume your `src/app.js` entry file imports pages from the sibling `src/pages/*` directory:

--- a/test/index.js
+++ b/test/index.js
@@ -71,6 +71,74 @@ test('routes', t => {
 });
 
 
+test('routes :: filter', t => {
+	// setup
+	const compilation = toBundle(DEFAULT.chunks, DEFAULT.modules);
+	const Plugin = new RouteManifest({
+		headers: true,
+		routes(str) {
+			return str.includes('Home') ? false : DEFAULT.routes(str);
+		}
+	});
+	// end setup
+
+	Plugin.run(compilation);
+	const { assets } = compilation;
+
+	const filename = 'manifest.json';
+	t.true(filename in assets, '~> created "manifest.json" file (default)');
+
+	const contents = assets[filename].source();
+	t.is(typeof contents, 'string', '~> saved contents a JSON string');
+	t.true(contents.startsWith(`{\n  "*"`), '~> is NOT minified by default');
+	t.is(typeof assets[filename].size(), 'number', '~> has `size()` getter for webpack');
+
+	const data = JSON.parse(contents);
+	t.same(Object.keys(data), ['*', '/:slug'], '~> has patterns as keys; NO HOME');
+
+	t.is(
+		// re-stringify; tape deepequal is unreliable
+		JSON.stringify(data),
+		JSON.stringify({
+			'*': {
+				files: [
+					{ type: 'script', href: '/bundle.1234.js' },
+					{ type: 'style', href: '/bundle.612d.css' },
+					{ type: 'image', href: '/link.svg' },
+				],
+				headers: [{
+					key: 'Link',
+					value: [
+						'</bundle.1234.js>; rel=preload; as=script; crossorigin=anonymous',
+						'</bundle.612d.css>; rel=preload; as=style',
+						'</link.svg>; rel=preload; as=image',
+					].join(', ')
+				}]
+			},
+			'/:slug': {
+				files: [
+					{ type: 'script', href: '/2.abc1.js' },
+					{ type: 'style', href: '/2.avsj2.css' },
+					{ type: 'image', href: '/avatar.png' },
+					{ type: 'font', href: '/font.ttf' }
+				],
+				headers: [{
+					key: 'Link',
+					value: [
+						'</2.abc1.js>; rel=preload; as=script; crossorigin=anonymous',
+						'</2.avsj2.css>; rel=preload; as=style',
+						'</avatar.png>; rel=preload; as=image',
+						'</font.ttf>; rel=preload; as=font; crossorigin=anonymous',
+					].join(', ')
+				}]
+			}
+		})
+	);
+
+	t.end();
+});
+
+
 test('defaults', t => {
 	// setup
 	const compilation = toBundle(DEFAULT.chunks, DEFAULT.modules);


### PR DESCRIPTION
Behaves just like `options.assets` – allows your application to pick and choose which routes it actually wants to enable preloading for.